### PR TITLE
Change case of resource_group value

### DIFF
--- a/infrastructure-as-code-terraform.md
+++ b/infrastructure-as-code-terraform.md
@@ -138,7 +138,7 @@ In this section, you are going to look at how to scale the virtual server resour
    ```
    # a cloud object storage
    variable "resource_group" {
-     default     = "default"
+     default     = "Default"
      description = "resource group"
    }
    


### PR DESCRIPTION
In the provided code snippet for "ibm-cloud-object-storage.tf" in the "Add Cloud Object Storage Service and Scale Resources" section, the variable "resource_group" has a key default with a value "default": this did not work for me until I changed it to "Default".